### PR TITLE
Add .gitignore to ignore build, temp, and IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# Compiled Object files
+*.o
+*.obj
+
+# Executable files
+*.exe
+*.out
+*.app
+
+# Temporary files
+*.log
+*.tmp
+*.swp
+*.DS_Store
+
+# C++ build directories
+/build/
+/bin/
+/Debug/
+/Release/
+
+# Java build directories
+/bin/
+/target/
+/*.class
+
+# Python temporary files
+__pycache__/
+*.pyc
+*.pyo
+
+# IDE/editor files
+.vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace
+
+# MacOS system files
+.DS_Store
+
+# Linux temporary files
+*~


### PR DESCRIPTION
#4 
### Summary
This PR adds a `.gitignore` file to the repository to prevent unnecessary files from being tracked by Git. 

### What it ignores
- **Compiled binaries and object files:** `.o`, `.obj`, `.exe`, `.out`, etc.  
- **Language-specific build directories:** `build/`, `bin/`, `Debug/`, `Release/`, `target/`  
- **Python cache files:** `__pycache__/`, `.pyc`, `.pyo`  
- **Editor/IDE settings:** `.vscode/`, `.idea/`, Sublime project/workspace files  
- **Temporary/system files:** `.DS_Store`, `*~`, `.log`, `.tmp`, `.swp`

### Benefits
- Keeps the repository clean and free of temporary or build artifacts.  
- Makes cloning and contributing easier for new contributors.  
- Prevents accidental commits of unnecessary files from multiple languages and IDEs.

This `.gitignore` is tailored for DSA-LeetCode contributors working with **C++, Java, Python**, and common IDEs.
